### PR TITLE
limacharlie 0.10 needs beach v0.4.3.1 instead of latest v0.4.4

### DIFF
--- a/cloud/infrastructure/1_install_single_node_test_cluster.py
+++ b/cloud/infrastructure/1_install_single_node_test_cluster.py
@@ -53,7 +53,7 @@ printStep( 'Installing some basic packages required for Beach (mainly).',
     os.system( 'apt-get install python-pip python-dev debconf-utils python-m2crypto python-pexpect python-mysqldb autoconf libtool git flex -y' ) )
 
 printStep( 'Installing Beach.',
-    os.system( 'pip install beach' ) )
+    os.system( 'pip install beach==0.4.3.1' ) )
 
 printStep( 'Installing JRE for Cassandra (the hcp-scale-db)',
     os.system( 'apt-get install default-jre-headless -y' ) )


### PR DESCRIPTION
In py-beach 0.4.4, the `Actor._run()` method is calling `self.init()` with an additional `self._resources` parameters, previously absent.

https://github.com/refractionPOINT/py-beach/blob/0.4.4/beach/actor.py#L162